### PR TITLE
Add keepalive step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/Checkin.yml
+++ b/.github/workflows/Checkin.yml
@@ -26,3 +26,5 @@ jobs:
         shell: bash
         run: |
           node main.js
+
+      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
This commit integrates the keepalive-workflow action to prevent workflow timeouts. It ensures that long-running workflows remain active and complete successfully.